### PR TITLE
Refactor for mobile-first, add lazy loading & code splitting

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -21,10 +21,10 @@ body {
 
 .App-header {
   background-color: #282c34;
-  padding: 10px 20px; /* Reduced padding */
+  padding: 8px 15px; /* Mobile padding */
   color: white;
   text-align: center;
-  font-size: 1.2rem; /* Slightly smaller header */
+  font-size: 1rem; /* Mobile font size */
   flex-shrink: 0; /* Prevent header from shrinking */
 }
 
@@ -38,7 +38,7 @@ body {
 .messages {
   flex-grow: 1;
   overflow-y: auto; /* Enable scrolling for messages */
-  padding: 20px;
+  padding: 10px; /* Mobile padding */
   display: flex;
   flex-direction: column;
   gap: 10px; /* Spacing between messages */
@@ -47,7 +47,7 @@ body {
 .message {
   padding: 10px 15px;
   border-radius: 15px;
-  max-width: 75%; /* Slightly wider max-width */
+  max-width: 85%; /* Mobile max-width */
   word-wrap: break-word; /* Wrap long words */
   line-height: 1.4;
   position: relative; /* For loading dots */
@@ -102,7 +102,7 @@ body {
 
 .input-area {
   display: flex;
-  padding: 15px;
+  padding: 10px; /* Mobile padding */
   border-top: 1px solid #ddd;
   background-color: #f8f8f8;
   flex-shrink: 0; /* Prevent input area from shrinking */
@@ -110,22 +110,22 @@ body {
 
 .input-area input {
   flex-grow: 1;
-  padding: 10px 15px;
+  padding: 8px 12px; /* Mobile padding */
   border: 1px solid #ccc;
   border-radius: 20px;
   margin-right: 10px;
-  font-size: 1rem;
+  font-size: 0.95rem; /* Mobile font size */
   box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
 }
 
 .input-area button {
-  padding: 10px 20px;
+  padding: 8px 15px; /* Mobile padding */
   border: none;
   background-color: #007bff;
   color: white;
   border-radius: 20px;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 0.95rem; /* Mobile font size */
   transition: background-color 0.2s ease;
 }
 
@@ -138,27 +138,27 @@ body {
    cursor: not-allowed;
 }
 
-/* Basic responsiveness */
-@media (max-width: 600px) {
+/* Styles for screens larger than 600px */
+@media (min-width: 601px) {
   .App-header {
-    font-size: 1rem;
-    padding: 8px 15px;
+    font-size: 1.2rem; /* Desktop font size */
+    padding: 10px 20px; /* Desktop padding */
   }
   .messages {
-    padding: 10px;
+    padding: 20px; /* Desktop padding */
   }
   .message {
-    max-width: 85%;
+    max-width: 75%; /* Desktop max-width */
   }
   .input-area {
-    padding: 10px;
+    padding: 15px; /* Desktop padding */
   }
   .input-area input {
-    padding: 8px 12px;
-    font-size: 0.95rem;
+    padding: 10px 15px; /* Desktop padding */
+    font-size: 1rem; /* Desktop font size */
   }
   .input-area button {
-    padding: 8px 15px;
-    font-size: 0.95rem;
+    padding: 10px 20px; /* Desktop padding */
+    font-size: 1rem; /* Desktop font size */
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,9 @@
 // frontend/src/App.js
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import './App.css';
+
+// Dynamically import HelpSection
+const HelpSection = lazy(() => import('./components/HelpSection'));
 
 // Use relative path as Flask backend will serve API from the same origin in Cloud Run
 const SERVER_URL = '/chat';
@@ -9,7 +12,10 @@ function App() {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [showHelp, setShowHelp] = useState(false); // State for HelpSection visibility
   const messagesEndRef = useRef(null); // Ref to scroll to bottom
+
+  const toggleHelp = () => setShowHelp(prevShowHelp => !prevShowHelp); // Toggle HelpSection
 
   // Function to scroll to the bottom of the chat messages
   const scrollToBottom = () => {
@@ -77,6 +83,9 @@ function App() {
     <div className="App">
       <header className="App-header">
         <h1>Ž</h1>
+        <button onClick={toggleHelp} className="help-toggle-button" data-testid="toggle-help-button">
+          {showHelp ? 'Hide Help' : 'Show Help'}
+        </button>
       </header>
       <div className="chat-window">
         <div className="messages">
@@ -110,6 +119,11 @@ function App() {
           </button>
         </div>
       </div>
+      {showHelp && (
+        <Suspense fallback={<div className="loading-help" data-testid="help-section-loading">Loading help...</div>}>
+          <HelpSection />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,91 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+// Mock the fetch function
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ answer: 'Mocked bot response' }),
+  })
+);
+
+beforeEach(() => {
+  // Clear all previous mock calls before each test
+  fetch.mockClear();
+});
+
+test('renders App and main components', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  // Check for header text (using text match as h1 might not have a specific role)
+  expect(screen.getByText(/Ž/i)).toBeInTheDocument(); // Header title
+  
+  // Check for input placeholder
+  expect(screen.getByPlaceholderText(/.../i)).toBeInTheDocument(); // Input field
+  
+  // Check for Send button
+  expect(screen.getByRole('button', { name: /Send/i })).toBeInTheDocument(); // Send button
+  
+  // Check for the help toggle button
+  expect(screen.getByTestId('toggle-help-button')).toBeInTheDocument();
+});
+
+test('lazy loads HelpSection when "Show Help" button is clicked', async () => {
+  render(<App />);
+
+  // Ensure HelpSection is not visible initially
+  expect(screen.queryByTestId('help-section-loaded')).not.toBeInTheDocument();
+
+  // Find and click the "Show Help" button
+  const showHelpButton = screen.getByTestId('toggle-help-button');
+  expect(showHelpButton).toHaveTextContent('Show Help'); // Initial button text
+  fireEvent.click(showHelpButton);
+
+  // Check for loading fallback
+  expect(screen.getByTestId('help-section-loading')).toBeInTheDocument();
+
+  // Wait for HelpSection to load and check for its content
+  // Using findByTestId which combines waitFor and getByTestId
+  const helpSection = await screen.findByTestId('help-section-loaded');
+  expect(helpSection).toBeInTheDocument();
+  expect(screen.getByText(/Help & FAQs/i)).toBeInTheDocument(); // Check for heading in HelpSection
+
+  // Check that the button text has changed
+  expect(showHelpButton).toHaveTextContent('Hide Help');
+
+  // Optional: Test hiding the section
+  fireEvent.click(showHelpButton);
+  expect(screen.queryByTestId('help-section-loaded')).not.toBeInTheDocument();
+  expect(showHelpButton).toHaveTextContent('Show Help'); // Button text back to Show Help
+});
+
+test('sending a message and receiving a response', async () => {
+  render(<App />);
+  const inputElement = screen.getByPlaceholderText(/.../i);
+  const sendButton = screen.getByRole('button', { name: /Send/i });
+
+  // Type a message and send
+  fireEvent.change(inputElement, { target: { value: 'Hello bot' } });
+  fireEvent.click(sendButton);
+
+  // Check if user message appears
+  expect(await screen.findByText(/Hello bot/)).toBeInTheDocument();
+  
+  // Check if fetch was called correctly
+  expect(fetch).toHaveBeenCalledWith('/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: 'Hello bot' }),
+  });
+
+  // Check for loading indicator for bot message
+  // The actual loading dots are multiple spans, so we check for the container
+  expect(screen.getByText((content, element) => element.classList.contains('loading') && element.classList.contains('bot'))).toBeInTheDocument();
+
+
+  // Wait for bot response
+  const botResponse = await screen.findByText(/Mocked bot response/);
+  expect(botResponse).toBeInTheDocument();
+
+  // Ensure loading indicator is gone
+  expect(screen.queryByText((content, element) => element.classList.contains('loading') && element.classList.contains('bot'))).not.toBeInTheDocument();
 });

--- a/frontend/src/components/HelpSection.css
+++ b/frontend/src/components/HelpSection.css
@@ -1,0 +1,17 @@
+.help-section {
+  padding: 20px;
+  margin-top: 15px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+}
+
+.help-section h2 {
+  margin-top: 0;
+  color: #333;
+}
+
+.help-section p {
+  color: #555;
+  line-height: 1.6;
+}

--- a/frontend/src/components/HelpSection.js
+++ b/frontend/src/components/HelpSection.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import './HelpSection.css';
+
+const HelpSection = () => {
+  return (
+    <div className="help-section" data-testid="help-section-loaded">
+      <h2>Help & FAQs</h2>
+      <p>This is a placeholder for help content and frequently asked questions.</p>
+      <p>More details will be added here later.</p>
+    </div>
+  );
+};
+
+export default HelpSection;


### PR DESCRIPTION
Key changes:

- I refactored `frontend/src/App.css` to adopt a mobile-first approach by converting `max-width` media queries to `min-width`. Base styles are now mobile, with overrides for larger screens.

- I introduced lazy loading for a new `HelpSection` component.
    - I created `frontend/src/components/HelpSection.js` and `HelpSection.css`.
    - I modified `frontend/src/App.js` to use `React.lazy()` and `<Suspense>` to load `HelpSection` on demand when a "Show Help" button is clicked.
    - This change enables code splitting, and `react-scripts` automatically creates separate chunks for lazy-loaded components, optimizing initial bundle size. I verified this by inspecting the build output.

- I added tests in `frontend/src/App.test.js`:
    - Basic test to ensure main app components render.
    - Test for lazy loading: verifies the "Show Help" button toggles visibility, the loading fallback appears, and the `HelpSection` content eventually renders.
    - Note: I encountered timeouts during test execution, so the pass/fail status of these tests is currently unconfirmed. Further investigation into the test environment or test setup may be needed.