### PR TITLE
🔒 Security Fix: Limit maximum query length in /chat endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,9 @@
 # /backend/main.py
 import os
-import textwrap
 import logging # Use logging instead of print for Cloud Run
 from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
-from langchain.vectorstores import FAISS
+from langchain_community.vectorstores import FAISS
 from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
 from langchain.chains import ConversationalRetrievalChain
 from langchain.memory import ConversationBufferWindowMemory
@@ -86,6 +85,10 @@ def chat():
     if not query:
         logging.warning("Received empty query in /chat request")
         return jsonify({"error": "Missing 'query' in request body"}), 400
+
+    if len(query) > 1000:
+        logging.warning(f"Received overly long query ({len(query)} chars). Rejecting.")
+        return jsonify({"error": "Query too long. Maximum length is 1000 characters."}), 400
 
     logging.info(f"Received query: {query[:50]}...") # Log snippet
     try:


### PR DESCRIPTION
🎯 **What:** Added a missing length limitation to the `query` field in the `/chat` API endpoint.
⚠️ **Risk:** Without a length limit, an attacker could send excessively large queries, potentially leading to resource exhaustion (Denial of Service) or causing large unexpected billing charges if passed through to external LLM APIs.
🛡️ **Solution:** Added a check to reject queries longer than 1000 characters with a `400 Bad Request` error before processing the prompt. Also removed an unused `textwrap` import and updated the `langchain.vectorstores.FAISS` import to `langchain_community.vectorstores.FAISS`.

---
*PR created automatically by Jules for task [9794271279747804454](https://jules.google.com/task/9794271279747804454) started by @maxwell-black*