### PR TITLE
🧹 Remove unused textwrap import from main.py

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,5 @@
 # /backend/main.py
 import os
-import textwrap
 import logging # Use logging instead of print for Cloud Run
 from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS


### PR DESCRIPTION
* 🎯 **What:** Removed the unused `import textwrap` from `backend/main.py`.
* 💡 **Why:** Removing unused imports reduces namespace clutter, improving code readability and maintainability.
* ✅ **Verification:** I confirmed that the import was entirely unused and the change is completely safe. Pre-commit tests and code review passed perfectly.
* ✨ **Result:** The code is cleaner, making it more concise without any behavioral changes to the application.

---
*PR created automatically by Jules for task [1696420500829404503](https://jules.google.com/task/1696420500829404503) started by @maxwell-black*