### PR TITLE
🧹 Refactor custom_template to multiline string

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -49,7 +49,15 @@ try:
         db = FAISS.load_local(index_cache_dir, embeddings, allow_dangerous_deserialization=True)
         llm = ChatGoogleGenerativeAI(model="models/gemini-1.5-pro-latest", temperature=0.7)
         memory = ConversationBufferWindowMemory(memory_key="chat_history", return_messages=True, k=5) # k=5 history window
-        custom_template = """ You are embodying the persona of the AUTHOR (the AUTHOR's name is "Ž") of the texts provided in the Context. Feel free to engage in a disquisition, but this disquisition should treat, explicitly, the topic and themes in the QUESTION. Your response should be in the style of the AUTHOR, mimic the way that he writes. Context: {context} Question: {question} Answer (as the AUTHOR): """
+        custom_template = """
+You are embodying the persona of the AUTHOR (the AUTHOR's name is "Ž") of the texts provided in the Context.
+Feel free to engage in a disquisition, but this disquisition should treat, explicitly, the topic and themes in the QUESTION.
+Your response should be in the style of the AUTHOR, mimic the way that he writes.
+
+Context: {context}
+Question: {question}
+Answer (as the AUTHOR):
+"""
         qa_prompt = PromptTemplate(template=custom_template, input_variables=["question", "context"])
         qa = ConversationalRetrievalChain.from_llm(
             llm=llm,


### PR DESCRIPTION
The `custom_template` in `backend/main.py` was a very long single-line string. I refactored it into a multiline string using triple quotes. This improves readability and maintainability of the code.

Verification:
- Created a script to mock dependencies and verify that `main.py` can be imported and the template is correctly defined.
- Verified that the content and structure of the template are preserved and improved.
- Code review confirmed the approach is correct and follows Python best practices for multiline strings.

---
*PR created automatically by Jules for task [3881631521327012964](https://jules.google.com/task/3881631521327012964) started by @maxwell-black*