### PR TITLE
🔒 [security] Restrict overly permissive CORS policy

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -70,7 +70,19 @@ except Exception as e:
 # --- Flask Application ---
 # Serve static files from the react_build_dir relative to the app's root
 app = Flask(__name__, static_folder=react_build_dir, static_url_path='/')
-CORS(app) # Enable CORS, useful if you ever separate frontend/backend URLs
+
+# Configure CORS with restricted origins to prevent unauthorized cross-origin requests.
+# In production, the frontend is served from the same origin as the API.
+# Use the ALLOWED_ORIGINS environment variable to specify a comma-separated list of permitted origins.
+allowed_origins_env = os.environ.get("ALLOWED_ORIGINS", "")
+allowed_origins = [origin.strip() for origin in allowed_origins_env.split(",") if origin.strip()]
+
+if allowed_origins:
+    CORS(app, origins=allowed_origins)
+    logging.info(f"CORS enabled for origins: {allowed_origins}")
+else:
+    # If no origins are specified, CORS is not enabled, defaulting to same-origin only.
+    logging.info("CORS is disabled (same-origin only).")
 
 # --- API Endpoint ---
 @app.route('/chat', methods=['POST'])


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an overly permissive CORS policy that defaulted to allowing all origins (`*`).

⚠️ **Risk:** An unrestricted CORS policy allows any website to make requests to the backend API on behalf of a user. This can lead to unauthorized data access or actions if a user visits a malicious site while authenticated (similar to CSRF), and it generally increases the attack surface of the application.

🛡️ **Solution:** Updated `backend/main.py` to replace the permissive `CORS(app)` with a configuration that reads from the `ALLOWED_ORIGINS` environment variable. It parses a comma-separated list of trusted origins and only enables CORS for those specific domains. If the environment variable is empty or unset, CORS is not enabled, defaulting the application to the more secure Same-Origin Policy.

---
*PR created automatically by Jules for task [4658706276810227494](https://jules.google.com/task/4658706276810227494) started by @maxwell-black*